### PR TITLE
Set up cicd

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4.1.1
+      - name: Compose down potentially running old version
+        run: docker-compose -f app/docker-compose.yml down --remove-orphans --rmi all
+      - name: Compose Up
+        run: docker-compose -f app/docker-compose.yml up --build --force-recreate -d

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  JUnit-Recipes:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+    - name: Preparation
+      run: |
+        docker-compose -f app/docker-compose.yml up --build --force-recreate -d database
+        sed -i 's/database:3306/localhost:3306/' app/backend/recipes/src/main/resources/application.properties
+    - name: Build
+      run: mvn package -DskipTests --file app/backend/recipes/pom.xml
+    - name: Test
+      run: mvn test --file app/backend/recipes/pom.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,9 @@ jobs:
   JUnit-Recipes:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4.0.0
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -39,10 +39,24 @@ services:
     ports:
       - "3306:3306"
     restart: unless-stopped 
-    volumes:
-      - ./database/init/init.sql:/docker-entrypoint-initdb.d/dump.sql
+    #volumes:
+      #- ./database/init/init.sql:/docker-entrypoint-initdb.d/dump.sql
     environment:
       - MARIADB_ROOT_PASSWORD=dummyrootpassword
       - MARIADB_DATABASE=juotava
       - MARIADB_USER=dummyuser
       - MARIADB_PASSWORD=dummypassword
+
+  proxy:
+    container_name: proxy
+    image: haproxy:latest
+    ports:
+      - "80:80"
+    depends_on:
+      - frontend
+      - backend-recipe
+      #- backend-bartinder
+      #- backend-maps
+    restart: unless-stopped
+    volumes:
+      - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro

--- a/app/haproxy.cfg
+++ b/app/haproxy.cfg
@@ -1,0 +1,22 @@
+global
+    log stdout format raw local0
+
+defaults
+    log global
+    mode http
+    option httplog
+    timeout connect 5000
+    timeout client 50000
+    timeout server 50000
+
+frontend http-in
+    bind *:80
+    default_backend react
+    acl api_path path_beg -i "/api/recipes"
+    use_backend spring_recipes if api_path
+
+backend react
+    server react frontend:3000 check
+
+backend spring_recipes
+    server spring_recipes backend-recipes:8080 check


### PR DESCRIPTION
I set up:
 - tests pipeline for any (atm) junit test we want to run or just to check if the project still compiles
 - deploy pipeline to always deploy the current state of main to juotava.mush-it.com. I tested this with a fork of the project, to make sure it works before merging this to main.

I also added a HAProxy container to the docker-compose, which accepts all requests on port 80 and then redistributes that to the react frontend or spring backend(s). 
This lets us handle said redistribution on the project level instead of hard configuring this on the server side which is what we did with dhbwcd. This should also prevent some CORS errors when working locally.