### PR TITLE
Add frontend auth

### DIFF
--- a/app/docker-compose-dev.yml
+++ b/app/docker-compose-dev.yml
@@ -1,16 +1,21 @@
 services:
   frontend:
     container_name: frontend
-    build: ./frontend
+    build: 
+      context: ./frontend
+      dockerfile: Dockerfile.Dev
     ports:
-      - "3000"
+      - "3000:3000"
+    volumes:
+      - /app/node_modules
+      - ./frontend:/app
     restart: unless-stopped
 
   backend-recipe:
     container_name: backend-recipes
     build: ./backend/recipes
     ports:
-      - "8080"
+      - "8080:8080"
     restart: unless-stopped
     depends_on:
       - database

--- a/app/frontend/Dockerfile.Dev
+++ b/app/frontend/Dockerfile.Dev
@@ -1,0 +1,5 @@
+FROM node:latest
+WORKDIR /app
+COPY . .
+RUN npm ci
+CMD ["npm", "run", "start"]

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@auth0/auth0-react": "^2.2.4",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -30,9 +31,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg=="
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
+      "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ=="
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -56,6 +57,23 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@auth0/auth0-react": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-react/-/auth0-react-2.2.4.tgz",
+      "integrity": "sha512-l29PQC0WdgkCoOc6WeMAY26gsy/yXJICW0jHfj0nz8rZZphYKrLNqTRWFFCMJY+sagza9tSgB1kG/UvQYgGh9A==",
+      "dependencies": {
+        "@auth0/auth0-spa-js": "^2.1.3"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17 || ^18",
+        "react-dom": "^16.11.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/@auth0/auth0-spa-js": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.3.tgz",
+      "integrity": "sha512-NMTBNuuG4g3rame1aCnNS5qFYIzsTUV5qTFPRfTyYFS1feS6jsCBR+eTq9YkxCp1yuoM2UIcjunPaoPl77U9xQ=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.23.4",
@@ -8468,9 +8486,9 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@auth0/auth0-react": "^2.2.4",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -8,23 +8,30 @@ import Add from './components/Add';
 import Bartinder from './components/Bartinder';
 import User from './components/User';
 import About from './components/About';
+import { AuthGuard } from './components/auth/AuthGuard';
+import { createContext } from 'react';
+import AuthenticatedRequestWrapper from './components/auth/AuthenticatedRequestWrapper';
+
+export const AuthenticatedRequestWrapperContext = createContext(AuthenticatedRequestWrapper);
 
 function App() {
   return (
     <div className="App">
-      <BrowserRouter>
-        <Navibar cyClass="cy-navBarNav"/>
-        <ErrorModal />
-        <Routes>
-          <Route path='/' element={<Home />}/>
-          <Route path='/search' element={<Search />}/>
-          <Route path='/add' element={<Add />}/>
-          <Route path='/bartinder' element={<Bartinder />}/>
-          <Route path='/user' element={<User />}/>
-          <Route path='/about' element={<About />}/>
-          <Route path='*' element={<h1>404</h1>} />
-        </Routes>
-      </BrowserRouter>
+      <AuthenticatedRequestWrapperContext.Provider value={new AuthenticatedRequestWrapper()}>
+        <BrowserRouter>
+          <Navibar cyClass="cy-navBarNav"/>
+          <ErrorModal />
+          <Routes>
+            <Route path='/' element={<Home />}/>
+            <Route path='/search' element={<Search />}/>
+            <Route path='/add' element={<Add />}/>
+            <Route path='/bartinder' element={<Bartinder />}/>
+            <Route path='/user' element={<AuthGuard component={User}/>}/>
+            <Route path='/about' element={<About />}/>
+            <Route path='*' element={<h1>404</h1>} />
+          </Routes>
+        </BrowserRouter>
+      </AuthenticatedRequestWrapperContext.Provider>
     </div>
   );
 }

--- a/app/frontend/src/components/Navibar.js
+++ b/app/frontend/src/components/Navibar.js
@@ -4,6 +4,7 @@ import Nav from 'react-bootstrap/Nav';
 import { NavLink } from 'react-router-dom';
 
 import logo from "../icons/Juotava_Draft_Icon.png";
+import LogInIndicator from './auth/LogInIndicator';
 
 function Navibar(props) {
     return (
@@ -15,27 +16,23 @@ function Navibar(props) {
         </Nav>
         <Nav>
           <Nav.Link as={NavLink} to="/search">
-            <span class="material-icons">
+            <span className="material-icons">
               search
             </span>
           </Nav.Link>
           <Nav.Link as={NavLink} to="/add">
-            <span class="material-icons">
+            <span className="material-icons">
               add_circle_outline
             </span>
           </Nav.Link>
           <Nav.Link as={NavLink} to="/bartinder">
-            <span class="material-icons">
+            <span className="material-icons">
               local_fire_department
             </span>
           </Nav.Link>
         </Nav>
         <Nav>
-          <Nav.Link as={NavLink} to="/user">
-            <span class="material-icons">
-              person
-            </span>
-        </Nav.Link>
+          <LogInIndicator />
         </Nav>
       </Navbar>
     );

--- a/app/frontend/src/components/User.js
+++ b/app/frontend/src/components/User.js
@@ -1,5 +1,9 @@
-import React from 'react';
+import {React, useContext, useEffect, useState} from 'react';
 import { useNavigate } from 'react-router';
+import LogOutButton from './auth/LogOutButton';
+import { useAuth0 } from '@auth0/auth0-react';
+import { baseUrlRecipes } from '../config/config';
+import { AuthenticatedRequestWrapperContext } from '../App';
 
 function User(props) {
     let style = { width: 'auto', cursor: 'pointer', padding: '0' };
@@ -8,8 +12,29 @@ function User(props) {
     }
     const navigate = useNavigate();
     const cyClass = (props.cyClass !== undefined) ? " "+props.cyClass : "";
+    const arw = useContext(AuthenticatedRequestWrapperContext);
+    const {user, isAuthenticated, getAccessTokenSilently} = useAuth0();
+
+    //auth request demo
+    const [recipe, setRecipe] = useState({});
+    useEffect(() => {
+        console.log('User useEffect');
+        arw.request({isAuthenticated, getAccessTokenSilently}, baseUrlRecipes, 'test', 'GET', undefined, setRecipe, true);
+    }, []);
+    
+    
     return (
-        <h1>User page</h1>
+        <>
+            <h1>User page</h1>
+            <h3>Auth Info:</h3>
+            <p>isAuthenticated: {isAuthenticated.toString()}</p>
+            <p>Auth0 userdata: {JSON.stringify(user)}</p>
+            <LogOutButton />
+            
+            <h3> Authenticated Request Demo (Recipe)</h3>
+            <p> Recipe: {recipe.title}</p>
+            
+        </>
     );
 }
 export default User;

--- a/app/frontend/src/components/auth/AuthGuard.js
+++ b/app/frontend/src/components/auth/AuthGuard.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { withAuthenticationRequired } from "@auth0/auth0-react";
+
+export const AuthGuard = ({ component }) => {
+    const Component = withAuthenticationRequired(component, {
+      
+    });
+  
+    return <Component />;
+  };

--- a/app/frontend/src/components/auth/AuthenticatedRequestWrapper.js
+++ b/app/frontend/src/components/auth/AuthenticatedRequestWrapper.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useAuth0 } from "@auth0/auth0-react";
+
+class AuthenticatedRequestWrapper{
+    async request({isAuthenticated, getAccessTokenSilently},backend, path='', method='GET', body=undefined, stateFunction=undefined, debug=false){
+        if (!isAuthenticated) {
+            return null;
+        }
+        (async () => {
+            let token = await getAccessTokenSilently();
+            const response = await fetch(backend+'/'+path, {
+                method: method,
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    'Content-Type': 'application/json'
+                },
+                body: body
+            });
+            if(debug) { console.log(response); }
+            if (stateFunction !== undefined) {
+                try {
+                    let data = await response.json();
+                    stateFunction(data);
+                } catch (error) {
+                    console.error(
+                        'Error while applying response to state in AuthenticatedRequestWrapper.request to '+backend+'/'+path+': ', error);
+                }
+            }
+        })();
+    }
+    
+}
+export default AuthenticatedRequestWrapper;

--- a/app/frontend/src/components/auth/LogInIndicator.js
+++ b/app/frontend/src/components/auth/LogInIndicator.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useAuth0 } from "@auth0/auth0-react";
+import Nav from 'react-bootstrap/Nav';
+import { NavLink } from 'react-router-dom';
+
+function LogInIndicator(){
+    const { user, loginWithRedirect, logout, isAuthenticated } = useAuth0();
+    return (
+        (isAuthenticated) ? (<>
+            <Nav.Link as={NavLink} to="/user">
+                <span className="material-icons">
+                manage_accounts
+                </span>
+            </Nav.Link>
+        </>):(<>
+            <Nav.Link onClick={() => loginWithRedirect()}>
+                <span className="material-icons">
+                person
+                </span>
+            </Nav.Link>
+        </>)
+    );
+
+}
+export default LogInIndicator;

--- a/app/frontend/src/components/auth/LogOutButton.js
+++ b/app/frontend/src/components/auth/LogOutButton.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useAuth0 } from "@auth0/auth0-react";
+
+function LogOutButton(){
+    const { logout } = useAuth0();
+    
+    return (
+        <button onClick={() => logout({ returnTo: window.location.origin })}>
+            Log Out
+        </button>
+    );
+}
+export default LogOutButton;

--- a/app/frontend/src/config/config.js
+++ b/app/frontend/src/config/config.js
@@ -1,0 +1,6 @@
+export const baseUrlAuth        = 'juotava.eu.auth0.com';
+export const clientId           = 'tIz6aRu6dYFAoFXMUUJG8wRJmHS9cahO';
+export const audience           = 'https://juotava.mush-it.com/api/';
+
+export const baseUrlRecipes        = '/api/recipes';
+export const baseUrlUser           = '/api/user';

--- a/app/frontend/src/index.js
+++ b/app/frontend/src/index.js
@@ -5,11 +5,21 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'material-icons/iconfont/material-icons.css'
+import { Auth0Provider } from '@auth0/auth0-react';
+import { audience, baseUrlAuth, clientId } from './config/config';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <Auth0Provider
+      domain={baseUrlAuth}
+      clientId={clientId}
+      authorizationParams={{
+        redirect_uri: window.location.origin,
+        audience: audience
+      }}>
+      <App />
+    </Auth0Provider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
- Added a `docker-compose-dev.yml` that runs the react app in dev mode and listens to file changes. This means to develop in the frontend and have functioning requests to the backend you can start the whole project via `docker compose -f docker-compose-dev.yml up --build` and access it on `localhost:80` and it behave just as when running `npm run start` but the backend is available and no need to change any configs or worry about CORS errors.
- Removed exposed ports 3000 and 8080 for frontend and backend in the *normal* docker compose (all should be accessed via :80/:443 of the proxy)
- Removed a redundant `package-lock.json` in project top level (probably got created by running `npm i`outside of `app/frontend`
- Added everything we need for Auth0 Authentication to the frontend.
- Changed the Icon of `User` component to reflect the current login state. Doubles as Login Button (`LogInIndicator` Component, more a debug thing, design definitely not final)
- Added an `AuthGuard` component that can be used to require authentication for certain components
- Implemented `AuthGuard` for `User` component.
- Implemented `AuthenticatedRequestWrapper`, a class to handle the authentication hassle for backend calls that can be used in any component.
- Implemented an examplatory use of ÀuthenticatedRequestWrapper` in `User` component
- Filled the `User` component with debug info on the Auth0 userdata and the response of a demo authenticated backend call that requests a randomly generated recipe. (to be removed later when we actually use the component)
- Added demo `LogOutButton`component and added it to `User`