### PR TITLE
User save

### DIFF
--- a/app/frontend/src/components/auth/AuthenticatedRequestWrapper.js
+++ b/app/frontend/src/components/auth/AuthenticatedRequestWrapper.js
@@ -44,11 +44,9 @@ class AuthenticatedRequestWrapper{
                     if (res === 'true') { // if the response is 'true', it is 'success'
                         successFunction('success');
                         if (debug) { console.log("Request was successful, because response was 'true'"); }
-                        stateFunction(res);
                     } else if (uuidRegex.test(res)) { // if the response is a UUID, it is 'success'
                         successFunction('success');
                         if (debug) { console.log("Request was successful, because "+res +" is a valid UUID"); }
-                        stateFunction(res);
                     } else { // if the response can be successfully parsed as JSON, it is 'success'
                         if (res === 'false') { // if the response is 'false', it is 'error'
                             if (debug) { console.log("Request was not successful, because response was 'false'"); }

--- a/app/frontend/src/components/auth/AuthenticatedRequestWrapper.js
+++ b/app/frontend/src/components/auth/AuthenticatedRequestWrapper.js
@@ -35,7 +35,6 @@ class AuthenticatedRequestWrapper{
             }
             try {
                 if (method === 'GET') { // if the request is GET, it is 'success' if the response can be successfully parsed as JSON
-                    console.log('GET');
                     let res = await responseClone.json();
                     successFunction('success');
                     if (debug) { console.log("Request was successful, because of valid json:", res); }

--- a/app/frontend/src/components/settings/user/User.js
+++ b/app/frontend/src/components/settings/user/User.js
@@ -38,7 +38,6 @@ function User(props) {
     }
 
     const handleChangeUsername = (event) => {
-        //console.log(event.target.value);
         const newUsername = event.target.value;
         setUserSet(prevUserSet => ({
             ...prevUserSet,
@@ -47,7 +46,6 @@ function User(props) {
     }
 
     const handleChangeShowUsername = (event) => {
-        //console.log(event.target.checked);
         const newShowUsername = event.target.checked;
         setUserSet(prevUserSet => ({
             ...prevUserSet,
@@ -61,7 +59,7 @@ function User(props) {
     const [saveUserSuccess, setSaveUserSuccess] = useState();
     const handleSave = () => {
         setSaveUserSuccess("waiting");
-        arw.request({isAuthenticated, getAccessTokenSilently}, baseUrlUser, 'user/save', 'POST', JSON.stringify(userSet), undefined, setSaveUserSuccess, true);
+        arw.request({isAuthenticated, getAccessTokenSilently}, baseUrlUser, 'user/save', 'POST', JSON.stringify(userSet), undefined, setSaveUserSuccess, false);
     }
 
     const [userSet, setUserSet] = useState(
@@ -74,7 +72,7 @@ function User(props) {
     const [userSetSuccess, setUserSetSuccess] = useState();
     useEffect(() => {
         setUserSetSuccess("waiting");
-        arw.request({isAuthenticated, getAccessTokenSilently}, baseUrlUser, 'user/my', 'GET', undefined, setUserSet, setUserSetSuccess, true);
+        arw.request({isAuthenticated, getAccessTokenSilently}, baseUrlUser, 'user/my', 'GET', undefined, setUserSet, setUserSetSuccess, false);
     }, []);
     
     


### PR DESCRIPTION
I fixed the incorrect "saving failed" message in the user settings even though it was saved.
The issue was a wrong (and redundant) use of the setState function in the arw. It was also used in the part which is used to decide if a request was successfull.

I also reduced the verbosity in the user settings by setting some debug flags to false and removing console logs