### PR TITLE
Drink of the day

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Insert OpenAI API key to recipes backend
         run: |
           sed -i "s/dummykey/${{ secrets.OPENAI_KEY }}/g" app/backend/recipes/src/main/resources/application.properties
+      - name: Insert WeatherAPI key to recipes backend
+        run: |
+          sed -i "s/dummyweatherkey/${{ secrets.WEATHERAPI_KEY }}/g" app/backend/recipes/src/main/resources/application.properties
       - name: Compose down potentially running old version
         run: docker-compose -f app/docker-compose.yml down --remove-orphans --rmi all
       - name: Compose Up

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/controller/RecipesController.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/controller/RecipesController.java
@@ -156,4 +156,13 @@ public class RecipesController {
         return this.recipesService.getFilterByUser(auth0id, true);
     }
 
+    //
+    // Drink of the day
+    //
+
+    @GetMapping(path = "drinkoftheday")
+    public DrinkOfTheDay getDrinkOfTheDay(){
+        return this.recipesService.getDrinkOfTheDay();
+    }
+
 }

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/DrinkOfTheDay.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/DrinkOfTheDay.java
@@ -1,0 +1,59 @@
+package com.juotava.recipes.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Entity
+@Getter
+public class DrinkOfTheDay {
+    @Id
+    @GeneratedValue
+    private UUID uuid;
+
+    private LocalDate date;
+
+    @Lob
+    @Column(columnDefinition = "LONGTEXT")
+    @Setter
+    private String reasoning;
+
+    private UUID parsedRecipeUuid;
+
+    @ManyToOne//(fetch = FetchType.LAZY)
+    @Setter
+    private Recipe recipe;
+
+    public DrinkOfTheDay(Date date) {
+        this.date = LocalDate.now();
+        this.reasoning = null;
+        this.recipe = null;
+        this.parsedRecipeUuid = null;
+    }
+
+    public DrinkOfTheDay(LocalDate date, String fromString){
+        this.date = date;
+        Pattern pattern = Pattern.compile("<ID: (.*?), REASON: (.*?)>");
+        Matcher matcher = pattern.matcher(fromString);
+        if (matcher.find()){
+            this.parsedRecipeUuid = UUID.fromString(matcher.group(1));
+            this.reasoning = matcher.group(2);
+        } else {
+            throw new IllegalArgumentException(fromString+" can't be parsed");
+        }
+    }
+
+    public DrinkOfTheDay() {
+        this.date = LocalDate.now();
+        this.reasoning = null;
+        this.recipe = null;
+        this.parsedRecipeUuid = null;
+    }
+}

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/Recipe.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/Recipe.java
@@ -92,4 +92,10 @@ public class Recipe {
         }
         return prompt;
     }
+
+    public String toRecipeOfTheDayString(){
+        return "<ID: "+ this.uuid +
+                ", Title: " + this.title +
+                ", Description: " + this.description + ">";
+    }
 }

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/imagegen/Data.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/imagegen/Data.java
@@ -1,4 +1,4 @@
-package com.juotava.recipes.model.dto;
+package com.juotava.recipes.model.dto.imagegen;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/imagegen/ImageRequest.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/imagegen/ImageRequest.java
@@ -1,4 +1,4 @@
-package com.juotava.recipes.model.dto;
+package com.juotava.recipes.model.dto.imagegen;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.juotava.recipes.model.Recipe;

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/imagegen/ImageResponseSuccess.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/imagegen/ImageResponseSuccess.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Getter
 @Setter
-public class ImageResposeSuccess {
+public class ImageResponseSuccess {
     private int created;
     private List<Data> data;
 }

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/imagegen/ImageResposeSuccess.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/imagegen/ImageResposeSuccess.java
@@ -1,4 +1,4 @@
-package com.juotava.recipes.model.dto;
+package com.juotava.recipes.model.dto.imagegen;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/textgen/Choice.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/textgen/Choice.java
@@ -1,0 +1,18 @@
+package com.juotava.recipes.model.dto.textgen;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Choice {
+    private int index;
+    private Message message;
+    private String finish_reason;
+
+    public Choice(int index, Message message, String finish_reason) {
+        this.index = index;
+        this.message = message;
+        this.finish_reason = finish_reason;
+    }
+}

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/textgen/Message.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/textgen/Message.java
@@ -1,0 +1,16 @@
+package com.juotava.recipes.model.dto.textgen;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Message {
+    private String role;
+    private String content;
+
+    public Message(String role, String content) {
+        this.role = role;
+        this.content = content;
+    }
+}

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/textgen/TextRequest.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/textgen/TextRequest.java
@@ -1,0 +1,28 @@
+package com.juotava.recipes.model.dto.textgen;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class TextRequest {
+    private String model;
+    private List<Message> messages;
+
+    public TextRequest(String model, List<Message> messages) {
+        this.model = model;
+        this.messages = messages;
+    }
+
+    public TextRequest(String model) {
+        this.model = model;
+        this.messages = new ArrayList<>();
+    }
+
+    public void addMessage(Message message){
+        this.messages.add(message);
+    }
+}

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/textgen/TextResponseSuccess.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/textgen/TextResponseSuccess.java
@@ -1,0 +1,29 @@
+package com.juotava.recipes.model.dto.textgen;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+@Getter
+@Setter
+public class TextResponseSuccess {
+    private String id;
+    private String object;
+    private Timestamp created;
+    private String model;
+    private List<Choice> choices;
+    private Usage usage;
+    private String system_fingerprint;
+
+    public TextResponseSuccess(String id, String object, Timestamp created, String model, List<Choice> choices, Usage usage, String system_fingerprint) {
+        this.id = id;
+        this.object = object;
+        this.created = created;
+        this.model = model;
+        this.choices = choices;
+        this.usage = usage;
+        this.system_fingerprint = system_fingerprint;
+    }
+}

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/textgen/Usage.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/textgen/Usage.java
@@ -1,0 +1,18 @@
+package com.juotava.recipes.model.dto.textgen;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Usage {
+    private int completion_tokens;
+    private int prompt_tokens;
+    private int total_tokens;
+
+    public Usage(int completion_tokens, int prompt_tokens, int total_tokens) {
+        this.completion_tokens = completion_tokens;
+        this.prompt_tokens = prompt_tokens;
+        this.total_tokens = total_tokens;
+    }
+}

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/weather/Condition.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/weather/Condition.java
@@ -1,0 +1,9 @@
+package com.juotava.recipes.model.dto.weather;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public class Condition {
+    private String text;
+}

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/weather/Day.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/weather/Day.java
@@ -1,0 +1,26 @@
+package com.juotava.recipes.model.dto.weather;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Day {
+
+    private double maxtemp_c;
+    private double mintemp_c;
+    private double avgtemp_c;
+    private double totalprecip_mm;
+    private double maxwind_kph;
+    private int avghumidity;
+    private int daily_chance_of_rain;
+    private int daily_chance_of_snow;
+    private Condition condition;
+
+    @Override
+    public String toString() {
+        return "The weather is "+condition.getText() +" with a maximum temperature of "+ maxtemp_c+ " Celsius, minimum temperature of "+mintemp_c+ " Celsius an average temperature of "+ avgtemp_c+" Celcius. "+
+                "The wind has a maximum speed of "+ maxwind_kph+" kph. The average humidity is "+avghumidity+"%. "+
+                "The chance of rain is "+ daily_chance_of_rain+"% and the chance of snow is "+daily_chance_of_snow+"% resulting in a total percipation of "+totalprecip_mm+"mm.";
+    }
+}

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/weather/Forecast.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/weather/Forecast.java
@@ -1,0 +1,11 @@
+package com.juotava.recipes.model.dto.weather;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+public class Forecast {
+    private List<ForecastDay> forecastday;
+}

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/weather/ForecastDay.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/weather/ForecastDay.java
@@ -1,0 +1,12 @@
+package com.juotava.recipes.model.dto.weather;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+public class ForecastDay {
+    private String date;
+    private Day day;
+}

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/weather/WeatherResponseSuccess.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/dto/weather/WeatherResponseSuccess.java
@@ -1,0 +1,9 @@
+package com.juotava.recipes.model.dto.weather;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public class WeatherResponseSuccess {
+    private Forecast forecast;
+}

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/repository/drinkOfTheDay/DrinkOfTheDayRepository.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/repository/drinkOfTheDay/DrinkOfTheDayRepository.java
@@ -1,0 +1,36 @@
+package com.juotava.recipes.repository.drinkOfTheDay;
+
+import com.juotava.recipes.model.DrinkOfTheDay;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.UUID;
+
+@Repository
+public class DrinkOfTheDayRepository {
+    private SpringDrinkOfTheDayRepository springDrinkOfTheDayRepository;
+
+    @Autowired
+    public DrinkOfTheDayRepository(SpringDrinkOfTheDayRepository springDrinkOfTheDayRepository) {
+        this.springDrinkOfTheDayRepository = springDrinkOfTheDayRepository;
+    }
+
+    public DrinkOfTheDay findByUuid(UUID uuid){
+        return this.springDrinkOfTheDayRepository.findById(uuid).get();
+    }
+
+    public DrinkOfTheDay findByDate(LocalDate date){
+        return this.springDrinkOfTheDayRepository.findByDate(date);
+    }
+
+    public DrinkOfTheDay findByDateToday(){
+        return this.springDrinkOfTheDayRepository.findByDate(LocalDate.now());
+    }
+
+    public void save(DrinkOfTheDay drinkOfTheDay){
+        this.springDrinkOfTheDayRepository.save(drinkOfTheDay);
+    }
+}

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/repository/drinkOfTheDay/SpringDrinkOfTheDayRepository.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/repository/drinkOfTheDay/SpringDrinkOfTheDayRepository.java
@@ -1,0 +1,12 @@
+package com.juotava.recipes.repository.drinkOfTheDay;
+
+import com.juotava.recipes.model.DrinkOfTheDay;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.UUID;
+
+public interface SpringDrinkOfTheDayRepository extends JpaRepository<DrinkOfTheDay, UUID> {
+    public DrinkOfTheDay findByDate(LocalDate date);
+}

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/service/RecipesService.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/service/RecipesService.java
@@ -321,7 +321,7 @@ public class RecipesService {
 
         String recipesString = recipes.stream().map(Recipe::toRecipeOfTheDayString).collect(Collectors.joining(","));
         TextRequest request = new TextRequest(textModel);
-        request.addMessage(new Message("system", "You are a deciding machine. I will give you a list of Recipes in the format <ID: XXX, Title: YYY, Description: ZZZ>, a date and some weather data. Based on these information you must decide on which Recipe you choose as the drink of the day. Keep in mind that some drinks are better fitted in certain seasons or temperatures. Consider Holidays or special Events. Give a sound reasoning text in German. Include some Trivia in the reasoning. Do not mention exact numbers on weather data in the reasoning. You answer must under all circumstances follow: <ID: XXX, REASON: YYY>. Do not write any additional text!"));
+        request.addMessage(new Message("system", "You are a deciding machine. I will give you a list of Recipes in the format <ID: XXX, Title: YYY, Description: ZZZ>, a date and some weather data. Based on these information you must decide on which Recipe you choose as the drink of the day. Keep in mind that some drinks are better fitted in certain seasons or temperatures. Consider Holidays or special Events. Give a sound reasoning text in German. Use the colloquial 'Du'. Include some Trivia in the reasoning. Do not mention exact numbers on weather data in the reasoning. You answer must under all circumstances follow: <ID: XXX, REASON: YYY>. Do not write any additional text!"));
         request.addMessage(new Message("user",
                 "Today is "+date.toString() +" " +
                         weather + " " +

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/service/RecipesService.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/service/RecipesService.java
@@ -3,7 +3,7 @@ package com.juotava.recipes.service;
 import com.juotava.recipes.model.*;
 import com.juotava.recipes.model.Image;
 import com.juotava.recipes.model.dto.imagegen.ImageRequest;
-import com.juotava.recipes.model.dto.imagegen.ImageResposeSuccess;
+import com.juotava.recipes.model.dto.imagegen.ImageResponseSuccess;
 import com.juotava.recipes.model.dto.textgen.Message;
 import com.juotava.recipes.model.dto.textgen.TextRequest;
 import com.juotava.recipes.model.dto.textgen.TextResponseSuccess;
@@ -18,7 +18,6 @@ import com.juotava.recipes.repository.step.StepRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -28,7 +27,6 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.List;
@@ -246,7 +244,7 @@ public class RecipesService {
 
     public Image generateImage(String prompt, String user){
         ImageRequest request = new ImageRequest(prompt, imageModel, 1, "hd", "b64_json", user);
-        ImageResposeSuccess response = openaiRestTemplate.postForObject(imageApiUrl, request, ImageResposeSuccess.class);
+        ImageResponseSuccess response = openaiRestTemplate.postForObject(imageApiUrl, request, ImageResponseSuccess.class);
 
         if (response == null || response.getData() == null || response.getData().isEmpty()) {
             return null;

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/service/RecipesService.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/service/RecipesService.java
@@ -321,7 +321,7 @@ public class RecipesService {
 
         String recipesString = recipes.stream().map(Recipe::toRecipeOfTheDayString).collect(Collectors.joining(","));
         TextRequest request = new TextRequest(textModel);
-        request.addMessage(new Message("system", "You are a deciding machine. I will give you a list of Recipes in the format <ID: XXX, Title: YYY, Description: ZZZ>, a date and some weather data. Based on these information you must decide on which Recipe you choose as the drink of the day. Keep in mind that some drinks are better fitted in certain seasons or temperatures. Consider Holidays or special Events. Give a sound reasoning text in German. Use the colloquial 'Du'. Include some Trivia in the reasoning. Do not mention exact numbers on weather data in the reasoning. You answer must under all circumstances follow: <ID: XXX, REASON: YYY>. Do not write any additional text!"));
+        request.addMessage(new Message("system", "You are a deciding machine. I will give you a list of Recipes in the format <ID: XXX, Title: YYY, Description: ZZZ>, a date and some weather data. Based on these information you must decide on which Recipe you choose as the drink of the day. Keep in mind that some drinks are better fitted in certain seasons or temperatures. Consider Holidays or special Events. Give a sound reasoning text in German. Use the colloquial 'Du'. Include some Trivia in the reasoning. Do not mention exact numbers on weather data in the reasoning. Your answer must under all circumstances follow: <ID: XXX, REASON: YYY>. Do not write any additional text!"));
         request.addMessage(new Message("user",
                 "Today is "+date.toString() +" " +
                         weather + " " +

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/service/RecipesService.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/service/RecipesService.java
@@ -340,7 +340,7 @@ public class RecipesService {
                 );
                 return  drinkOfTheDay;
             } catch (Exception e){
-                System.out.println("ERROR: Versuch "+(i+1)+". Ein Drink des Tages konnte nicht generiert werden. Vermutlich hatte GPT keine Lust 🥲");
+                System.out.println("ERROR: Attempt "+(i+1)+". A drink of the day could not be generated. This is most likely due to GPT giving a non-conforming answer.");
             }
         }
         return null;

--- a/app/backend/recipes/src/main/resources/application.properties
+++ b/app/backend/recipes/src/main/resources/application.properties
@@ -12,6 +12,8 @@ auth0.audience=https://juotava.mush-it.com/api/
 auth0.domain=juotava.eu.auth0.com
 spring.security.oauth2.resourceserver.jwt.issuer-uri=https://${auth0.domain}/
 
-openai.model=dall-e-3
-openai.api.url=https://api.openai.com/v1/images/generations
+openai.model.images=dall-e-3
+openai.api.url.images=https://api.openai.com/v1/images/generations
+openai.model.text=gpt-4
+openai.api.url.text=https://api.openai.com/v1/chat/completions
 openai.api.key=dummykey

--- a/app/backend/recipes/src/main/resources/application.properties
+++ b/app/backend/recipes/src/main/resources/application.properties
@@ -17,3 +17,7 @@ openai.api.url.images=https://api.openai.com/v1/images/generations
 openai.model.text=gpt-4
 openai.api.url.text=https://api.openai.com/v1/chat/completions
 openai.api.key=dummykey
+
+weatherapi.api.url=https://api.weatherapi.com/v1/forecast.json?key=${weatherapi.api.key}&q=${weatherapi.api.location}&days=1&hour=0
+weatherapi.api.location=Karlsruhe Germany
+weatherapi.api.key=dummyweatherkey

--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -23,9 +23,9 @@ function App() {
           <Navibar cyClass="cy-navBarNav"/>
           <ErrorModal />
           <Routes>
-            <Route path='/' element={<Home />}/>
-            <Route path='/browser' element={<Browser />}/>
-            <Route path='/browser/recipe/:uuid' element={ <Recipe /> } />
+            <Route path='/' element={<AuthGuard component={Home}/>}/>
+            <Route path='/browser' element={<AuthGuard component={Browser}/>}/>
+            <Route path='/browser/recipe/:uuid' element={<AuthGuard component={Recipe}/>} />
             <Route path='/composer/:editUuid?' element={<AuthGuard component={Composer}/>}/>
             <Route path='/bartinder' element={<AuthGuard component={Bartinder} />}/>
             <Route path='/settings' element={<AuthGuard component={Settings}/>}/>

--- a/app/frontend/src/components/general/RecipeCard.js
+++ b/app/frontend/src/components/general/RecipeCard.js
@@ -20,6 +20,7 @@ function RecipeCard({excerpt, handleClick}) {
     const [ingrString, setIngrString] = useState("");
     
     return (
+        recipeExcerpt !== undefined &&
         <Card onClick={handleClick} style={{paddingLeft: 0, paddingRight: 0}}>
             <Row className='g-0'>
                 <Col sm='auto'>

--- a/app/frontend/src/components/home/DayDrinkCard.js
+++ b/app/frontend/src/components/home/DayDrinkCard.js
@@ -1,38 +1,25 @@
 import {Col, Container, Row, Card} from 'react-bootstrap';
 import placeholderImage from '../../image-placeholder.jpeg'
+import { useEffect, useState } from 'react';
+import TextTruncate from 'react-text-truncate';
 
-function DayDrinkCard(props) {
+function DayDrinkCard({drinkOfTheDay}) {
+    const [drink, setDrink] = useState(drinkOfTheDay);
+    useEffect(() => {
+        setDrink(drinkOfTheDay);
+    }, [drinkOfTheDay]);
+
     return (
-        <Card className="text-center" style={{width: '18rem', paddingLeft: 0, paddingRight: 0 }}>
+        drink !== undefined &&
+        <Card>
             <Card.Header>
-                <Card.Title>Drink des Tages</Card.Title>
+                <Card.Title>Warum dieser Drink?</Card.Title>
             </Card.Header>
-            <Card.Img variant='bottom' src={placeholderImage} alt='...' style={{width:'auto'}} />
-            <Card.Footer>
-                <Row>
-                    <Col xs='3' className="justify-content-start">
-                        <span className="material-icons">
-                            favorite_border
-                        </span>
-                        <Card.Text className='text-muted'>
-                            1,3K
-                        </Card.Text>
-                    </Col>
-                    <Col xs='6' className="justify-content-center">
-                        <Card.Text>
-                            Drink Name
-                        </Card.Text>
-                    </Col>
-                    <Col xs='3' className="justify-content-end">
-                        <span className="material-icons">
-                            star_border
-                        </span>
-                        <Card.Text>
-                            4,7
-                        </Card.Text>
-                    </Col>
-                </Row>
-            </Card.Footer>
+            <Card.Body>
+                <Card.Text>
+                    {drink?.reasoning}
+                </Card.Text>
+            </Card.Body>
         </Card>
     );
 }

--- a/app/frontend/src/components/home/Home.js
+++ b/app/frontend/src/components/home/Home.js
@@ -5,6 +5,7 @@ import { AuthenticatedRequestWrapperContext } from '../../App';
 import { useAuth0 } from '@auth0/auth0-react';
 import { baseUrlRecipes } from '../../config/config';
 import RecipeCard from '../general/RecipeCard';
+import { useNavigate } from 'react-router-dom';
 
 function Home(props) {
     const arw = useContext(AuthenticatedRequestWrapperContext);
@@ -12,6 +13,7 @@ function Home(props) {
     const [loadDrinkOfTheDaySuccess, setLoadDrinkOfTheDaySuccess] = useState('');
     const [showLoadingMessage, setShowLoadingMessage] = useState(false);
     const [drinkOfTheDay, setDrinkOfTheDay] = useState();
+    const navigate = useNavigate();
 
     useEffect(() => {
         setLoadDrinkOfTheDaySuccess('waiting');
@@ -47,7 +49,7 @@ function Home(props) {
                     <Col xs={12} sm={8}>
                         <Row className="justify-content-center mb-5">
                             <Col>
-                                <RecipeCard excerpt={drinkOfTheDay?.recipe} />
+                                <RecipeCard handleClick={() => navigate('/browser/recipe/'+drinkOfTheDay?.recipe.uuid)} excerpt={drinkOfTheDay?.recipe} />
                             </Col>
                         </Row>
                         <Row className="justify-content-center mb-5">

--- a/app/frontend/src/components/home/Home.js
+++ b/app/frontend/src/components/home/Home.js
@@ -1,14 +1,68 @@
-import React from 'react';
+import {React, useContext, useEffect, useState } from 'react';
 import DayDrinkCard from './DayDrinkCard';
 import { Col, Row, Container } from 'react-bootstrap';
+import { AuthenticatedRequestWrapperContext } from '../../App';
+import { useAuth0 } from '@auth0/auth0-react';
+import { baseUrlRecipes } from '../../config/config';
+import RecipeCard from '../general/RecipeCard';
 
 function Home(props) {
+    const arw = useContext(AuthenticatedRequestWrapperContext);
+    const {isAuthenticated, getAccessTokenSilently} = useAuth0();
+    const [loadDrinkOfTheDaySuccess, setLoadDrinkOfTheDaySuccess] = useState('');
+    const [showLoadingMessage, setShowLoadingMessage] = useState(false);
+    const [drinkOfTheDay, setDrinkOfTheDay] = useState();
+
+    useEffect(() => {
+        setLoadDrinkOfTheDaySuccess('waiting');
+        arw.request({isAuthenticated, getAccessTokenSilently}, baseUrlRecipes, 'drinkoftheday', 'GET', undefined, setDrinkOfTheDay, setLoadDrinkOfTheDaySuccess, false);
+
+        setTimeout(() => {
+            setShowLoadingMessage(true);
+        }, 300);
+    }, []);
+
     return (
         <>
-            <h1 className='mb-5'>Willkommen</h1>
-            <Row className="justify-content-center mb-5"><DayDrinkCard /></Row>
-            <Container className='justify-content-center'>
-                <h2 className='mb-3'>Finde deinen Lieblingsdrink!</h2>
+            <Container className='justify-content-center pl-4 pr-4'>
+                <Row>
+                    <Col>
+                        <h1 className='mb-5'>Drink des Tages</h1>
+                    </Col>
+                </Row>
+                {loadDrinkOfTheDaySuccess === 'waiting' && showLoadingMessage && 
+                    <Row className='justify-content-center'>
+                        <Col className='text-center'>
+                            <h4>Drink des Tages wird gerade frisch für dich zubereitet. Bitte warte noch einen Moment.</h4>
+                        </Col>
+                    </Row>}
+                {loadDrinkOfTheDaySuccess === 'error' && 
+                    <Row className='justify-content-center'>
+                        <Col className='text-center'>
+                            <h4>Bei der Zubereitung des Drink des Tages ist ein Fehler aufgetreten.</h4> 
+                            <p>Wir werden ein ernstes Wörtchen mit dem Barkeeper reden. Bitte versuche es später noch einmal.</p>
+                        </Col>
+                    </Row>}
+                <Row className='justify-content-center'>
+                    <Col xs={12} sm={8}>
+                        <Row className="justify-content-center mb-5">
+                            <Col>
+                                <RecipeCard excerpt={drinkOfTheDay?.recipe} />
+                            </Col>
+                        </Row>
+                        <Row className="justify-content-center mb-5">
+                            <Col>
+                                <DayDrinkCard drinkOfTheDay={drinkOfTheDay} />
+                            </Col>
+                        </Row>
+                    </Col>
+                </Row>
+                
+                <Row>
+                    <Col>
+                    <h2 className='mb-3'>Finde deinen Lieblingsdrink!</h2>
+                    </Col>
+                </Row>
                 <Row className="text-center">
                     <Col>cocktails</Col>
                     <Col>coffee</Col>

--- a/app/frontend/src/index.js
+++ b/app/frontend/src/index.js
@@ -11,7 +11,6 @@ import { audience, baseUrlAuth, clientId } from './config/config';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
     <Auth0Provider
       domain={baseUrlAuth}
       clientId={clientId}
@@ -21,7 +20,6 @@ root.render(
       }}>
       <App />
     </Auth0Provider>
-  </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
Okay, Ive been cooking something:
For the home screens drink of the day I was wondering on how to decide which existing recipe to choose.
That's when I realized we don't have to come up with any groundbreaking algorithm nor implement any complex machine learning to train a recommendation. We could just use GPT, provide it with some background information like the current date and the weather and ask it for a recommendation and reasoning text.
So basically how it works is:
1. Get today's weather forecast from "weatherapi"
2. Parse all currently existing published recipes (might need to limit to a few randomly selected ones in the future, not sure what the token limit is).
3. Send to GPT
4. get an answer in the format `<ID: XXX, REASON: YYY>`
5. If GPT does something weird or ID is not a valid or existing UUID of a recipe, try up to 3 times.
6. Create a drink of the day object, persist and return to user
7. Display the drink of the day and reasoning text on the home screen.

Notes: 
- I have reused the recipeCard, so any upcoming improvements there should also effect the drink of the day.
- If you want to test locally remember to fill the `openai.api.key` and now new `weatherapi.api.key` in the recipes backends `application.properties`. The corresponding values can be found in postman.