### PR TITLE
Recipes deletable via button in edit view

### DIFF
--- a/app/backend/recipes/src/main/java/com/juotava/recipes/controller/RecipesController.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/controller/RecipesController.java
@@ -93,6 +93,12 @@ public class RecipesController {
         return this.recipesService.getRecipe(uuid, auth0id);
     }
 
+    @DeleteMapping(path = "recipe/{uuid}")
+    public boolean deleteRecipe(@PathVariable UUID uuid, Authentication authentication){
+        String auth0id = authentication.getName();
+        return this.recipesService.deleteRecipe(uuid, auth0id);
+    }
+
     /*
         Endpoints /recipeexcerpt/*
         Interact with recipe excerpts

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/model/RecipeList.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/model/RecipeList.java
@@ -18,7 +18,7 @@ public class RecipeList {
     @Column(length = 30)
     private String title;
 
-    @ManyToMany(fetch = FetchType.LAZY)
+    @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Recipe> recipes;
 
     private String createdBy;

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/repository/recipe/RecipeRepository.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/repository/recipe/RecipeRepository.java
@@ -38,4 +38,8 @@ public class RecipeRepository {
     public void save(Recipe recipe){
         this.springRecipeRepository.save(recipe);
     }
+
+    public void delete(Recipe recipe) {
+        this.springRecipeRepository.delete(recipe);
+    }
 }

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/repository/recipeList/RecipeListRepository.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/repository/recipeList/RecipeListRepository.java
@@ -38,4 +38,8 @@ public class RecipeListRepository {
     public RecipeList getFavoritesList(String auth0id){
         return this.springRecipeListRepository.findByCreatedByAndTitle(auth0id, "Favoriten");
     }
+
+    public List<RecipeList> findByRecipeId(UUID recipeId){
+        return this.springRecipeListRepository.findByRecipeId(recipeId);
+    }
 }

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/repository/recipeList/SpringRecipeListRepository.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/repository/recipeList/SpringRecipeListRepository.java
@@ -2,6 +2,8 @@ package com.juotava.recipes.repository.recipeList;
 
 import com.juotava.recipes.model.RecipeList;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.UUID;
@@ -9,4 +11,7 @@ import java.util.UUID;
 public interface SpringRecipeListRepository extends JpaRepository<RecipeList, UUID> {
     public List<RecipeList> findByCreatedBy(String auth0id);
     public RecipeList findByCreatedByAndTitle(String auth0id, String title);
+
+    @Query("SELECT rl FROM RecipeList rl JOIN rl.recipes r WHERE r.uuid = :recipeId")
+    List<RecipeList> findByRecipeId(@Param("recipeId") UUID recipeId);
 }

--- a/app/backend/recipes/src/main/java/com/juotava/recipes/service/RecipesService.java
+++ b/app/backend/recipes/src/main/java/com/juotava/recipes/service/RecipesService.java
@@ -276,6 +276,23 @@ public class RecipesService {
         return this.removeRecipeFromList(favoriteList.getUuid(), recipeId, auth0id);
     }
 
+    public boolean deleteRecipe(UUID recipeId, String auth0id) {
+        try {
+            Recipe recipe = this.recipeRepository.findByUuid(recipeId);
+            if (!auth0id.equals(recipe.getCreatedBy())){
+                System.out.println("ERROR: Recipe "+ recipe.getUuid()+" exists but does not belong to user "+recipe.getCreatedBy());
+                return false;
+            }
+            List<RecipeList> recipeLists = this.recipeListRepository.findByRecipeId(recipeId);
+            recipeLists.forEach(list -> list.removeRecipeFromList(recipe));
+            this.recipeRepository.delete(recipe);
+            return true;
+        } catch (Exception e){
+            System.out.println("ERROR: Could not find recipe with UUID: " + recipeId);
+            return false;
+        }
+    }
+
     public RecipeExcerptsList getRecipeList(UUID listId, String auth0id) {
         try {
             RecipeList originalList = this.recipeListRepository.findByUuid(listId);

--- a/app/frontend/src/components/composer/Composer.js
+++ b/app/frontend/src/components/composer/Composer.js
@@ -26,7 +26,9 @@ function Composer() {
     ));
     const [loadRecipeSuccess, setLoadRecipeSuccess] = useState("");
     const [saveRecipeSuccess, setSaveRecipeSuccess] = useState("");
+    const [deleteRecipeSuccess, setDeleteRecipeSuccess] = useState("");
     const [uuid, setUuid] = useState();
+    const [editMode, setEditMode] = useState(false);
 
     const handleChangeImage = (data) => {
         setRecipe({...recipe, image: data})
@@ -66,7 +68,7 @@ function Composer() {
         tmp.draft = draft;
         tmp.createdBy = user.sub;
         setRecipe((prevRecipe) => ({...prevRecipe, draft: draft, createdBy: user.sub}));
-        arw.request({isAuthenticated, getAccessTokenSilently}, baseUrlRecipes, 'recipe/save', 'POST', JSON.stringify(tmp), setUuid, setSaveRecipeSuccess, true);
+        arw.request({isAuthenticated, getAccessTokenSilently}, baseUrlRecipes, 'recipe/save', 'POST', JSON.stringify(tmp), setUuid, setSaveRecipeSuccess, false);
     }
 
     const validateRecipe = (recipe) => {
@@ -82,8 +84,18 @@ function Composer() {
         navigate('/browser/recipe/'+uuid);
     }
 
+    const handleOpenBrowser = () => {
+        navigate('/browser');
+    }
+
+    const handleDelete = () => {
+        setDeleteRecipeSuccess('waiting');
+        arw.request({isAuthenticated, getAccessTokenSilently}, baseUrlRecipes, 'recipe/'+ encodeURIComponent(editUuid), 'DELETE', undefined, undefined, setDeleteRecipeSuccess, true);
+    }
+
     useState(() => {
         if (editUuid !== undefined) {
+            setEditMode(true);
             setLoadRecipeSuccess('waiting');
             arw.request({isAuthenticated, getAccessTokenSilently}, baseUrlRecipes, 'recipe/'+ encodeURIComponent(editUuid), 'GET', undefined, setRecipe, setLoadRecipeSuccess, false);
         }
@@ -160,7 +172,8 @@ function Composer() {
                 <Row className="justify-content-center mb-3">
                     <Col xs="8">
                         <Button variant="primary" className="me-1" disabled={!validateRecipe(recipe)} onClick={() => handleSave(false)}>Veröffentlichen</Button>
-                        <Button variant="secondary" disabled={!validateRecipe(recipe)} onClick={() => handleSave(true)}>Entwurf speichern</Button>
+                        <Button variant="secondary" className="me-1" disabled={!validateRecipe(recipe)} onClick={() => handleSave(true)}>Entwurf speichern</Button>
+                        {editMode && <Button variant='danger' disabled={!validateRecipe(recipe)} onClick={() => handleDelete()}>Löschen</Button>}
                     </Col>
                 </Row>
                 <Row className="justify-content-center mb-3">
@@ -173,6 +186,15 @@ function Composer() {
                         : null}
                         {saveRecipeSuccess === "error" ? 
                             <div>Speichern fehlgeschlagen</div>
+                        : null}
+                        {deleteRecipeSuccess === "waiting" ? 
+                            <Spinner animation="border" role="status" />
+                        : null}
+                        {deleteRecipeSuccess === "success" ? 
+                            handleOpenBrowser(uuid)
+                        : null}
+                        {deleteRecipeSuccess === "error" ? 
+                            <div>Löschen fehlgeschlagen</div>
                         : null}
                     </Col>
                 </Row>

--- a/app/frontend/src/components/general/Recipe.js
+++ b/app/frontend/src/components/general/Recipe.js
@@ -105,16 +105,16 @@ function Recipe(props) {
                 </Col>
                 <Col className="d-flex justify-content-end">
                     {recipe && user && recipe.createdBy === user.sub ?
-                        <Button variant="primary" onClick={editRecipe} className='text-white' style={{display: 'inline-flex', alignItems: 'center'}}>
+                        <Button variant="primary" onClick={editRecipe} className='text-white me-2' style={{display: 'inline-flex', alignItems: 'center'}}>
                             <span style={{marginRight: '.5rem'}}>Bearbeiten</span> <span className="material-icons">edit</span>
                         </Button>
                     :
                         null
                     }
-                    <Button variant="primary" className="d-flex align-items-center text-white" onClick={handleFavoriteClick}>
+                    <Button variant="primary" className="d-flex align-items-center text-white me-2" onClick={handleFavoriteClick}>
                         <span className="material-icons">favorite{!isFavorite && '_border'}</span>
                     </Button>
-                    <Dropdown className="d-inline mx-2">
+                    <Dropdown className="d-inline">
                         <Dropdown.Toggle id="dropdown-autoclose-true" className='d-flex align-items-center text-white'>
                             <span className="material-icons">playlist_add</span>
                         </Dropdown.Toggle>


### PR DESCRIPTION
* added deleteRecipe endpoint
** find with SQL search in springRepository only the recipeLists that contain the recipe so we don't have to get all lists
** remove the recipe from the specific lists
** delete the recipe from the database
--> this way we don't get problems with deleting parents of childs and foreignKeys
* adapted Composer frontend
** new handleDelete
** new const for editMode so the button is not visible when opening the general composer but only when editing